### PR TITLE
Replace isInstance() with callable() to allow functions and methods

### DIFF
--- a/ymodem/Protocol.py
+++ b/ymodem/Protocol.py
@@ -17,18 +17,18 @@ class Protocol(object):
 
     @reader.setter
     def reader(self, r):
-        if hasattr(r, "read") and isinstance(r.read, types.FunctionType):
+        if hasattr(r, "read") and callable(r.read):
             self._reader = r
-        elif isinstance(r, types.FunctionType):
+        elif callable(r):
             self._reader = RWBuilder(rFunc=r)
         else:
             raise TypeError("unknown type for reader")
     
     @writer.setter
     def writer(self, w):
-        if hasattr(w, "write") and isinstance(w.write, types.FunctionType):
+        if hasattr(w, "write") and callable(w.write):
             self._writer = w
-        elif isinstance(w, types.FunctionType):
+        elif callable(w):
             self._writer = RWBuilder(wFunc=w)
         else:
             raise TypeError("unknown type for writer")


### PR DESCRIPTION
I wanted to use class methods for the reader and writer hooks but found that this didn't work because a method is not a `types.FunctionType` but a `types.MethodType`.
You could of course write it as e.g.
```
if isinstance(r, (types.FunctionType, types.MethodType)):
```
but I find just using `if callable(r):` is much cleaner and also handles all callable objects.
See also https://stackoverflow.com/a/624948
