### PR TITLE
Enable batch mode for receiving multiple files, remove NAK on EOT

### DIFF
--- a/FileReceiver.py
+++ b/FileReceiver.py
@@ -31,6 +31,8 @@ if __name__ == '__main__':
     file_info = {
         "save_path"    :   os.path.abspath("remote")
     }
-    received = receiver.recv(stream=None, info=file_info)
+    received = 0
+    while received != None:
+        received = receiver.recv(stream=None, info=file_info)
 
     serial_io.close()

--- a/README.md
+++ b/README.md
@@ -47,19 +47,27 @@ def sender_write(data, timeout=3):
     serial_io.writeTimeout = timeout
     return serial_io.write(data)
 
-sender = Modem(sender_read, sender_write)
+ymodem = Modem(sender_read, sender_write)
 ```
 
 3. Send file
 
 ```python
-sender.send(stream, info=file_info)
+ymodem.send(stream, info=file_info)
 ```
 
-4. Receive file
+4. Receive single file
 
 ```python
-receiver.recv(stream, info=file_info)
+received = ymodem.recv(stream=None, info=file_info)
+```
+
+5. Receive multiple files in batch mode by calling `recv()` until it returns `None`
+
+```python
+received = 0
+while received != None:
+    received = ymodem.recv(stream=None, info=file_info)
 ```
 
 ## YMODEM for Python API
@@ -76,7 +84,7 @@ def __init__(self, reader, writer, mode='ymodem1k', program="rzsz")
 ### Send file (stream)
 
 ```python
-def send(self, stream, retry=10, timeout=10, callback=None, info=None):
+def send(self, stream, retry=10, timeout=10, callback=None, info=None)
 ```
 - stream, data stream.
 - retry, max retry count.
@@ -123,6 +131,10 @@ Field | Description
 -|- 
 save_path | folder path where the file are saved
 
+return value:
+
+- Size of received file in bytes if successful
+- `None` otherwise
 
 ## Changelog
 ### v1.2 (2022/8/10 14:00 +00:00)


### PR DESCRIPTION
A small change allows to call `recv()`in a loop to receive files in YMODEM batch mode. When the sender is done sending files, the last header contains an empty filename, that signals that the batch transfer is finished.

Also I removed the sending of a NAK when EOT is received. I think the protocol spec is a bit misleading there because it always shows the EOT-NAK-EOT-ACK sequence. But in 7.3.3 it is explained 
`When the sender has no more data, it sends an <eot>, and awaits an <ack>, resending the <eot> if it doesn't get one.`
So I would say that these EOT-NAK-EOT-ACK sequences are meant to show that the sender sends EOT until it gets a ACK and NOT that the receiver is required to first send a NAK.