### PR TITLE
fix: UnboundLocalError when path is empty list or all paths are invalid

### DIFF
--- a/ymodem/Socket.py
+++ b/ymodem/Socket.py
@@ -429,7 +429,7 @@ class ModemSocket(Channel):
             Transmission of a null pathname terminates batch file transmission.
             '''
 
-            if self.protocol_type == ProtocolType.YMODEM:
+            if tasks and self.protocol_type == ProtocolType.YMODEM:
                 header = self._make_send_header(self._packet_size, 0)
                 data = bytearray().ljust(self._packet_size, b"\x00")
                 checksum = self._make_send_checksum(crc, data)


### PR DESCRIPTION

```py
import serial
from ymodem.Socket import ModemSocket


ser = serial.Serial("COM6", 115200, timeout=3, write_timeout=3)


# define read
def read(size, timeout=3):
    # implementation
    return ser.read(size)


# define write
def write(data, timeout=3):
    # implementation
    ser.write(data)


# create socket
cli = ModemSocket(read, write)
# cli.send([])
cli.send(["./invalid_path"])
```

```txt
Traceback (most recent call last):
  File "D:\workbench\ymodem\tmp.py", line 23, in <module>
    cli.send(["./invalid_path"])
    ~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "D:\workbench\ymodem\ymodem\Socket.py", line 435, in send
    checksum = self._make_send_checksum(crc, data)
                                        ^^^
UnboundLocalError: cannot access local variable 'crc' where it is not associated with a value
```